### PR TITLE
Update make files

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -17,9 +17,12 @@ HW=$(CLASS_HW) \
 .PHONY: all copy
 all: $(HW)
 
-pdf/%.pdf: tex/%.tex
+pdf/%.pdf: tex/%.tex | pdf
 	xelatex -output-dir pdf $<
 	xelatex -output-dir pdf $<
+
+pdf: 
+	@mkdir -p pdf
 
 clean:
 	rm -f pdf/*.aux pdf/*.log pdf/*.out

--- a/lec/Makefile
+++ b/lec/Makefile
@@ -35,6 +35,8 @@ pdf/%.pdf: notes/%.tex
 # 	../util/pluto2html.sh $<
 
 clean:
+	rm -f pdf/*.bbl pdf/*.blg pdf/*.fls
+	rm -f pdf/*.fdb_latexmk pdf/*.xdv
 	rm -f pdf/*.aux pdf/*.log pdf/*.out
 	rm -f pdf/*.nav pdf/*.snm pdf/*.toc 
 	rm -f pdf/*.vrb


### PR DESCRIPTION
## Overview

This includes two simple quality-of-life updates for the make files. 

- In the `hw` directory,  `xelatex` fails to build because a subdirectory `pdf` does not exist. This adds a dependency for that directory and will `mkdir` if it doesn't exit.
- In the `lec` directory, `latexmk` generates a few extra files that `make clean` does not delete. This adds the `rm` commands to `make clean`. 